### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,10 +44,6 @@ application.router = prod.Routes
 
 play.filters {
   headers.contentSecurityPolicy = "frame-ancestors 'self'; default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 stats.g.doubleclick.net www.google-analytics.com app.optimizely.com cdn.optimizely.com *.optimizely.com optimizely.s3.amazonaws.com www.googletagmanager.com fonts.googleapis.com tagmanager.google.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com data:"
-  csrf.header.bypassHeaders {
-    X-Requested-With = "*"
-    Csrf-Token = "nocheck"
-  }
 }
 
 metrics {


### PR DESCRIPTION
The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051